### PR TITLE
Optimize isUrlAllow()

### DIFF
--- a/RobotsTxtValidator.php
+++ b/RobotsTxtValidator.php
@@ -9,8 +9,7 @@ class RobotsTxtValidator
 	/**
 	 * @var array
 	 */
-	private $rules;
-
+	private $orderedDirectives;
 	/**
 	 * RobotsTxtValidator constructor
 	 *
@@ -18,7 +17,9 @@ class RobotsTxtValidator
 	 */
 	public function __construct(array $rules)
 	{
-		$this->rules = $rules;
+		foreach($rules as $userAgent => $rulesByUserAgent) {
+			$this->orderedDirectives[$userAgent] = $this->orderDirectives($rules[$userAgent]);
+		}
 	}
 
 	/**
@@ -31,11 +32,10 @@ class RobotsTxtValidator
 	public function isUrlAllow($url, $userAgent = '*')
 	{
 		$relativeUrl = $this->getRelativeUrl($url);
-		$orderedDirectives = $this->getOrderedDirectivesByUserAgent($userAgent);
 
 		// if has not allow rules we can determine when url disallowed even on one coincidence - just to do it faster.
 		$hasAllowDirectives = true;
-		foreach ($orderedDirectives as $directiveRow) {
+		foreach ($this->orderedDirectives[$userAgent] as $directiveRow) {			
 			if ($directiveRow['directive'] == 'allow' ) {
 				$hasAllowDirectives = true;
 				break;
@@ -43,7 +43,7 @@ class RobotsTxtValidator
 		}
 
 		$isAllow = true;
-		foreach ($orderedDirectives as $directiveRow) {
+		foreach ($this->orderedDirectives[$userAgent] as $directiveRow) {			
 			if (!in_array($directiveRow['directive'], array('allow', 'disallow'))) {
 				continue;
 			}


### PR DESCRIPTION
Resolve [Issue12](https://github.com/bopoda/robots-txt-parser/issues/12) with initialization of  `orderedDirectives` during RobotsTxtValidator initialization 