### PR TITLE
Resolve iconv() notice error

### DIFF
--- a/RobotsTxtParser.php
+++ b/RobotsTxtParser.php
@@ -62,11 +62,13 @@ class RobotsTxtParser
 	public function __construct($content, $encoding = self::DEFAULT_ENCODING)
 	{
 		// convert encoding
-		$encoding = !empty($encoding) ? $encoding : mb_detect_encoding($content);
-		mb_internal_encoding($encoding);
-
+		$encoding = !empty($encoding) ? $encoding : mb_detect_encoding($content, mb_detect_order(), false);
+        	if($encoding == "UTF-8")
+        	{
+            		$content = mb_convert_encoding($content, 'UTF-8', 'UTF-8');    
+        	}
 		// set content
-		$this->content = iconv($encoding, 'UTF-8//IGNORE', $content);
+        	$this->content = iconv(mb_detect_encoding($content, mb_detect_order(), false), "UTF-8//IGNORE", $content);
 		$this->content .= "\n";
 
 		// set default state

--- a/RobotsTxtParser.php
+++ b/RobotsTxtParser.php
@@ -63,8 +63,7 @@ class RobotsTxtParser
 	{
 		// convert encoding
 		$encoding = !empty($encoding) ? $encoding : mb_detect_encoding($content, mb_detect_order(), false);
-        	if($encoding == "UTF-8")
-        	{
+        	if ($encoding == "UTF-8") {
             		$content = mb_convert_encoding($content, 'UTF-8', 'UTF-8');    
         	}
 		// set content


### PR DESCRIPTION
Some robots.tx files have invalid utf-8 contents. 
For example: 
   - http://www.optimic.com/robots.txt
   - http://www.dcga.fr/robots.txt
   - http://www.recoin.fr/robots.txt

This causes NOTICE: iconv(): Detected an incomplete multibyte character in input string.
This PR resolve this NOTICE: iconv() error.