### PR TITLE
Fix travisCI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,4 @@ jobs:
     - php: 7.3
 before_script:
   - composer dump-autoload
+script: vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ jobs:
     - php: 7.2
     - php: 7.3
 before_script:
-  - composer dump-autoload
+  - composer install
 script: vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,15 @@
 sudo: false
 language: php
-php:
-  - 5.4
-    dist: precise
-  - 5.5
-    dist: precise
-  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
-  - 7.3
+jobs:
+  include:
+    - php: 5.4
+      dist: precise
+    - php: 5.5
+      dist: precise
+    - 5.6
+    - 7.0
+    - 7.1
+    - 7.2
+    - 7.3
 before_script:
   - composer dump-autoload

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,15 @@
 sudo: false
 language: php
-dist: trusty
 jobs:
   include:
     - php: 5.4
       dist: precise
     - php: 5.5
       dist: precise
-    - 5.6
-    - 7.0
-    - 7.1
-    - 7.2
-    - 7.3
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+    - php: 7.2
+    - php: 7.3
 before_script:
   - composer dump-autoload

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ language: php
 jobs:
   include:
     - php: 5.4
-      dist: precise
     - php: 5.5
-      dist: precise
     - php: 5.6
     - php: 7.0
     - php: 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ sudo: false
 language: php
 php:
   - 5.4
+    dist: precise
   - 5.5
+    dist: precise
   - 5.6
   - 7.0
   - 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: php
+dist: trusty
 jobs:
   include:
     - php: 5.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ language: php
 jobs:
   include:
     - php: 5.4
+      dist: precise
     - php: 5.5
+      dist: precise
     - php: 5.6
     - php: 7.0
     - php: 7.1

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,6 @@
     "psr-4": {"RobotsTxtParser\\": "tests/RobotsTxtParser"}
   },
   "scripts": {
-    "test": "phpunit"
+    "test": "vendor/bin/phpunit"
   }
 }


### PR DESCRIPTION
- use php 5.4 and php 5.5 on dist **precise** because of no php 5.5 version on **trusty**
- use `phpunit` from vendor folder because of default-installed phpunit has inconsistency with php v.7.0 and v.7.1 by some reason on [TravisCI](https://travis-ci.org/bopoda/robots-txt-parser/jobs/604424772), for example:
```
$ phpunit
PHPUnit 7.5.0 by Sebastian Bergmann and contributors.
This version of PHPUnit is supported on PHP 7.1 and PHP 7.2.
You are using PHP 7.0.33 (/home/travis/.phpenv/versions/7.0.33/bin/php).
The command "phpunit" exited with 1.
```